### PR TITLE
CTE-51 restore clean overhaul

### DIFF
--- a/modules/backup.js
+++ b/modules/backup.js
@@ -9,21 +9,21 @@
  */
 var backup = function(type, oncomplete) {
 
-  var paths = window.ffosbr.settings.getBackupDirectoryPaths();
+  var paths = ffosbr.settings.getBackupDirectoryPaths();
 
-  if (typeof(ffosbr.settings.getPath(type)) === undefined) {
+  if (typeof paths[type] === undefined) {
     throw new Error('Invalid data type. Cannot restore type ' + type);
   }
 
-  window.ffosbr.media.get(type, function(file) {
+  ffosbr.media.get(type, function(file) {
     if (!file) {
       return;
     }
 
-    var filename = paths[type] + photo.name;
-    window.ffosbr.media.put('sdcard1', photo, filename, function() {
-      oncomplete();
-    });
+    var filename = paths[type] + file.name;
+    ffosbr.media.put('sdcard1', file, filename, function() {
+      // Report progress?
+    }, oncomplete);
   });
 };
 

--- a/modules/backup.js
+++ b/modules/backup.js
@@ -26,8 +26,10 @@ var backup = function(type, oncomplete) {
     ffosbr.media.put('sdcard1', file, dest, function() {
       // Report progress?
     });
-  }, function() {
-    oncomplete();
+  }, function(error) {
+    if (ffosbr.utils.isFunction(oncomplete)) {
+      oncomplete(error);
+    }
   });
 };
 

--- a/modules/backup.js
+++ b/modules/backup.js
@@ -11,19 +11,23 @@ var backup = function(type, oncomplete) {
 
   var paths = ffosbr.settings.getBackupDirectoryPaths();
 
-  if (typeof paths[type] === undefined) {
+  if (paths[type] === undefined) {
     throw new Error('Invalid data type. Cannot restore type ' + type);
   }
 
-  ffosbr.media.get(type, function(file) {
+  ffosbr.media.get(type === 'photos' ? 'pictures' : type, function(file) {
     if (!file) {
       return;
     }
 
-    var filename = paths[type] + file.name;
-    ffosbr.media.put('sdcard1', file, filename, function() {
+    var fn = file.name;
+    fn = fn.substr(fn.lastIndexOf('/') + 1, fn.length);
+    var dest = paths[type] + fn;
+    ffosbr.media.put('sdcard1', file, dest, function() {
       // Report progress?
-    }, oncomplete);
+    });
+  }, function() {
+    oncomplete();
   });
 };
 

--- a/modules/backup.js
+++ b/modules/backup.js
@@ -27,9 +27,7 @@ var backup = function(type, oncomplete) {
     ffosbr.media.put('sdcard1', file, dest, function() {
       // Report progress?
     });
-  }, ffosbr.utils.isFunction(oncomplete) ? function(error) {
-    oncomplete(error);
-  } : undefined);
+  }, oncomplete);
 };
 
 // Defines Ffosbr backup

--- a/modules/backup.js
+++ b/modules/backup.js
@@ -23,15 +23,13 @@ var backup = function(type, oncomplete) {
 
     var fn = file.name;
     fn = fn.substr(fn.lastIndexOf('/') + 1, fn.length);
-    var dest = paths[type] + fn;
+    var dest = paths[type] + fn + '~';
     ffosbr.media.put('sdcard1', file, dest, function() {
       // Report progress?
     });
-  }, function(error) {
-    if (ffosbr.utils.isFunction(oncomplete)) {
-      oncomplete(error);
-    }
-  });
+  }, ffosbr.utils.isFunction(oncomplete) ? function(error) {
+    oncomplete(error);
+  } : undefined);
 };
 
 // Defines Ffosbr backup

--- a/modules/backup.js
+++ b/modules/backup.js
@@ -6,6 +6,7 @@
  *   the callback, "oncomplete".
  * @param {string} type
  * @param {callback} oncomplete
+ * @throws On invalid data type
  */
 var backup = function(type, oncomplete) {
 

--- a/modules/clean.js
+++ b/modules/clean.js
@@ -26,9 +26,7 @@ var clean = function(type, oncomplete) {
         throw error;
       }
     });
-  }, ffosbr.utils.isFunction(oncomplete) ? function(error) {
-    oncomplete(error);
-  } : undefined);
+  }, oncomplete);
 
 };
 

--- a/modules/clean.js
+++ b/modules/clean.js
@@ -21,19 +21,14 @@ var clean = function(type, oncomplete) {
     }
 
     var filename = paths[type] + file.name;
-    alert(file.name);
     window.ffosbr.media.remove(file.name, function(error) {
       if (error) {
         throw error;
       }
     });
-  }, function(error) {
-    if (ffosbr.utils.isFunction(oncomplete)) {
-      oncomplete(error);
-    } else {
-      throw error;
-    }
-  });
+  }, ffosbr.utils.isFunction(oncomplete) ? function(error) {
+    oncomplete(error);
+  } : undefined);
 
 };
 

--- a/modules/clean.js
+++ b/modules/clean.js
@@ -6,6 +6,7 @@
  *   the callback, "oncomplete".
  * @param {string} type
  * @param {callback} oncomplete
+ * @throws On invalid data type
  */
 var clean = function(type, oncomplete) {
   var paths = ffosbr.settings.getBackupDirectoryPaths();

--- a/modules/clean.js
+++ b/modules/clean.js
@@ -8,37 +8,32 @@
  * @param {callback} oncomplete
  */
 var clean = function(type, oncomplete) {
+  var paths = ffosbr.settings.getBackupDirectoryPaths();
 
-  var externalSD = null;
-  var listFiles = null;
-  var paths = window.ffosbr.settings.getBackupDirectoryPaths();
-
-  if (typeof(paths[type]) === undefined) {
+  if (paths[type] === undefined) {
     throw new Error('Invalid data type. Cannot clean type ' + type);
   }
 
-  externalSD = window.ffosbr.media.getStorageByName('sdcard').external;
-
-  if (externalSD.ready === true) {
-    listFiles = externalSD.store.enumerate(paths[type]);
-  }
-
-  listFiles.onsuccess = function(file) {
+  ffosbr.media.get('sdcard1', paths[type], function(file) {
     if (!file) {
       return;
     }
 
     var filename = paths[type] + file.name;
-    window.ffosbr.media.remove(filename, function(error) {
+    alert(file.name);
+    window.ffosbr.media.remove(file.name, function(error) {
       if (error) {
         throw error;
       }
     });
-  };
+  }, function(error) {
+    if (ffosbr.utils.isFunction(oncomplete)) {
+      oncomplete(error);
+    } else {
+      throw error;
+    }
+  });
 
-  listFiles.onerror = function(event) {
-    oncomplete(event.target.error.name);
-  };
 };
 
 // Defines Ffosbr clean

--- a/modules/contacts.js
+++ b/modules/contacts.js
@@ -1,12 +1,11 @@
 /**
- * @access public
- * @description Takes contacts stored on the device and SIM or ICC card(s) and saves them
+ * Takes contacts stored on the device and SIM or ICC card(s) and saves them
  * to a JSON file on an external SD card.
  */
 var Contacts = function() {};
 
 /**
- * @access public
+ * @access private
  * @description Contacts initializer.
  */
 Contacts.prototype.initialize = function() {
@@ -62,6 +61,7 @@ Contacts.prototype.restore = function() {
 /**
  * @access private
  * @description Deletes contacts.json from the SD card if it exists.
+ * @param {callback} oncomplete
  */
 Contacts.prototype.clean = function(oncomplete) {
   var path = '/sdcard1/' + ffosbr.settings.backupPaths.contacts + '/contacts.json';
@@ -176,6 +176,7 @@ Contacts.prototype.getContactsFromSIM = function() {
  * @access private
  * @description Writes the resulting JSON file to the SD card, removing any preexisting
  * file with the same name.
+ * @param {callback} oncomplete
  */
 Contacts.prototype.putContactsOnSD = function(oncomplete) {
   var that = this;

--- a/modules/history.js
+++ b/modules/history.js
@@ -1,6 +1,12 @@
+/**
+ * Manages internal and external storages, or handles to storage
+ * devices, and their various data sets, including apps, music,
+ * pictures, sdcard, and videos.
+ */
 function History() {}
 
 /**
+ * @access private
  * @description History constructor
  */
 History.prototype.initialize = function() {
@@ -10,6 +16,11 @@ History.prototype.initialize = function() {
   }
 };
 
+/**
+ * @access private
+ * @description Defaults for backup history
+ * @return Default values for backup history
+ */
 History.prototype.getDefault = function() {
   return {
     photos: {
@@ -40,6 +51,11 @@ History.prototype.getDefault = function() {
   };
 };
 
+/**
+ * @access private
+ * @description Loads backup history settings from local storage if they exist
+ * @return True if backup history settings was loaded from local storage otherwise False 
+ */
 History.prototype.loadHistory = function() {
   var retrievedHistory = localStorage.getItem('ffosbrHistory');
 
@@ -57,6 +73,11 @@ History.prototype.loadHistory = function() {
   return false;
 };
 
+/**
+ * @access private
+ * @description Loads backup history settings from local storage if they exist
+ * @return True if backup history settings was loaded from local storage otherwise False 
+ */
 History.prototype.get = function(field, subfield) {
   if (typeof field === 'undefined') {
     return this.history;
@@ -74,6 +95,12 @@ History.prototype.get = function(field, subfield) {
   return this.history[field];
 };
 
+/**
+ * @access private
+ * @description Validate all passed in history
+ * @para {object} potentialHistoryObject
+ * @return True if passed in history are valid otherwise false
+ */
 History.prototype.validateAll = function(potentialHistoryObject) {
   var hist = null;
   // If potentialHistoryObject was null, validate this object
@@ -102,6 +129,12 @@ History.prototype.validateAll = function(potentialHistoryObject) {
   return true;
 };
 
+/**
+ * @access private
+ * @description Validate a entry in history
+ * @para {object} potentialHistoryEntry
+ * @return True if passed in history entry is valid otherwise false
+ */
 History.prototype.validateEntry = function(potentialHistoryEntry) {
   if (typeof potentialHistoryEntry !== 'object') {
     return false;
@@ -126,6 +159,13 @@ History.prototype.validateEntry = function(potentialHistoryEntry) {
   return true;
 };
 
+/**
+ * @access private
+ * @description Validate a entrys field in history
+ * @para {String} field
+ * @para {Object} value
+ * @return True if passed in history entry field is valid otherwise false
+ */
 History.prototype.validateEntryField = function(field, value) {
   if (field === 'title') {
     return typeof value === 'string';
@@ -140,6 +180,13 @@ History.prototype.validateEntryField = function(field, value) {
   return false;
 };
 
+/**
+ * @access private
+ * @description Update field or object in history
+ * @para {Object} fieldNameOrHistoryObject
+ * @para {Object} historyValue
+ * @return True if history was updated otherwise false
+ */
 History.prototype.set = function(fieldNameOrHistoryObject, historyValue) {
   // Is the first argument a field name or a full history object?
   if (typeof fieldNameOrHistoryObject === 'string') {
@@ -158,6 +205,13 @@ History.prototype.set = function(fieldNameOrHistoryObject, historyValue) {
   return false;
 };
 
+/**
+ * @access public
+ * @description Get a field of history or the whole history object
+ * @para {String} field
+ * @para {String} subfield
+ * @return field of history or the whole history object
+ */
 History.prototype.get = function(field, subfield) {
   // If field is undefined, return the whole object
   if (typeof field === 'undefined') {

--- a/modules/history.js
+++ b/modules/history.js
@@ -98,7 +98,7 @@ History.prototype.get = function(field, subfield) {
 /**
  * @access private
  * @description Validate all passed in history
- * @para {object} potentialHistoryObject
+ * @param {object} potentialHistoryObject
  * @return True if passed in history are valid otherwise false
  */
 History.prototype.validateAll = function(potentialHistoryObject) {

--- a/modules/main.js
+++ b/modules/main.js
@@ -9,7 +9,10 @@
       'settings': require('./settings'),
       'history': require('./history'),
       'messages': require('./messages'),
-      'contacts': require('./contacts')
+      'contacts': require('./contacts'),
+      'photos': require('./photos'),
+      'videos': require('./videos'),
+      'music': require('./music')
     };
 
     /* Import classes */

--- a/modules/media.js
+++ b/modules/media.js
@@ -160,25 +160,31 @@ Media.prototype.get = function(type, directory, forEach, oncomplete) {
   external = storages.external;
 
   if (type === 'sdcard1') {
-    externalFiles = external.store.enumerate(directory);
+    externalFiles = external.store.enumerate();
+    if (directory && !directory.startsWith('/sdcard1/')) {
+      directory = '/sdcard1/' + directory;
+    }
   } else {
     // Fall back to empty objects to avoid errors providing
     // "onsuccess" callbacks to null variables.
+    directory = null;
     internalFiles = internal.store.enumerate();
     externalFiles = external.store.enumerate();
   }
 
   var onsuccess = function() {
     var file = this.result;
-    forEach(file);
     if (!file || this.done) {
       if (oncomplete !== undefined) {
         oncomplete();
       }
       return;
-    } else {
-      this.continue();
     }
+
+    if (!directory || file.name.startsWith(directory)) {
+      forEach(file);
+    }
+    this.continue();
   };
 
   var onerror = function() {

--- a/modules/media.js
+++ b/modules/media.js
@@ -170,10 +170,18 @@ Media.prototype.get = function(type, directory, forEach, oncomplete) {
   external = storages.external;
 
   if (type === 'sdcard1') {
-    externalFiles = external.store.enumerate();
-    if (directory && !directory.startsWith('/sdcard1/')) {
-      directory = '/sdcard1/' + directory;
+    if (directory) {
+      if (!directory.startsWith('/')) {
+        directory = '/' + directory;
+      }
+      if (!directory.startsWith('/sdcard1')) {
+        directory = '/sdcard1' + directory;
+      }
+      if (!directory.endsWith('/')) {
+        directory = directory + '/';
+      }
     }
+    externalFiles = external.store.enumerate();
   } else {
     // Fall back to empty objects to avoid errors providing
     // "onsuccess" callbacks to null variables.
@@ -312,18 +320,13 @@ Media.prototype.put = function(type, file, dest, oncomplete) {
 
       // The majority of errors thrown by Firefox OS do not provide messages.
       if (error.message.length > 0) {
-        if (oncomplete) {
-          oncomplete(error);
-        } else {
-          throw error;
-        }
+        oncomplete(error);
       } else {
-        if (oncomplete) {
-          oncomplete(new Error('Attempt to write to an invalid storage. Abort.'));
-          return;
-        }
-        throw new Error('Attempt to write to an invalid storage. Abort.');
+        alert(type + '\n' + filename + '\n' + file.name + '\n' + file.type);
+        oncomplete(new Error('Attempt to write to an invalid storage. Abort.'));
       }
+    } else {
+      throw new Error('Attempt to write to an invalid storage. Abort.');
     }
   };
 };

--- a/modules/media.js
+++ b/modules/media.js
@@ -172,7 +172,7 @@ Media.prototype.get = function(type, directory, forEach, oncomplete) {
     var file = this.result;
     forEach(file);
     if (!file || this.done) {
-      if (oncomplete) {
+      if (oncomplete !== undefined) {
         oncomplete();
       }
       return;
@@ -242,7 +242,7 @@ Media.prototype.put = function(type, file, dest, oncomplete) {
     if (storages.external !== null) {
       targetStorage = storages.external;
     } else {
-      throw new Error('Attempt to write to an invalid storage. Abort.');
+      throw new Error('Unable to locate SD card. Abort.');
     }
   } else {
     targetStorage = (storages.internal === null ? storages.external : storages.internal);
@@ -275,7 +275,7 @@ Media.prototype.put = function(type, file, dest, oncomplete) {
       if (error.message.length > 0) {
         oncomplete(error);
       } else {
-        oncomplete(new Error('Attempt to write to an invalid storage. Abort.'));
+        throw new Error('Attempt to write to an invalid storage. Abort.');
       }
     }
   };

--- a/modules/media.js
+++ b/modules/media.js
@@ -171,13 +171,20 @@ Media.prototype.get = function(type, directory, forEach, oncomplete) {
   var onsuccess = function() {
     var file = this.result;
     forEach(file);
-    if (this.done && oncomplete) {
-      oncomplete();
+    if (!file || this.done) {
+      if (oncomplete) {
+        oncomplete();
+      }
+      return;
+    } else {
+      this.continue();
     }
   };
 
   var onerror = function() {
-    oncomplete(new Error('Attempt to read from an invalid storage. Abort.'));
+    if (oncomplete) {
+      oncomplete(new Error('Attempt to read from an invalid storage. Abort.'));
+    }
   };
 
   internalFiles.onsuccess = onsuccess;

--- a/modules/media.js
+++ b/modules/media.js
@@ -13,7 +13,7 @@ function Media() {
     // 'music',
     'pictures',
     'sdcard',
-    // 'videos'
+    'videos'
   ];
 
   // Contains a storage {Storage} for each internal storage type.

--- a/modules/media.js
+++ b/modules/media.js
@@ -24,6 +24,7 @@ function Media() {
 }
 
 /**
+ * @access private
  * @description Media constructor
  */
 Media.prototype.initialize = function() {
@@ -154,7 +155,7 @@ Media.prototype.get = function(type, directory, forEach, oncomplete) {
 
   if (!ffosbr.utils.isFunction(forEach)) {
     if (ffosbr.utils.isFunction(oncomplete)) {
-      oncomplete(new Error('Missing or invalid callback));
+      oncomplete(new Error('Missing or invalid callback'));
       return;
     }
     throw new Error('Missing or invalid callback');
@@ -223,6 +224,7 @@ Media.prototype.get = function(type, directory, forEach, oncomplete) {
  * @param {File} file
  * @param {String} dest
  * @param {requestCallback} oncomplete (option)
+ * @throws on invalid media type
  */
 Media.prototype.put = function(type, file, dest, oncomplete) {
 
@@ -333,6 +335,7 @@ Media.prototype.put = function(type, file, dest, oncomplete) {
  * @param {String} filename - Specifies the full path to the file to be
  *   removed from the external sdcard (sdcard1).
  * @param {requestCallback} oncomplete (optional)
+ * @throws 
  */
 Media.prototype.remove = function(filename, oncomplete) {
 

--- a/modules/media.js
+++ b/modules/media.js
@@ -322,7 +322,6 @@ Media.prototype.put = function(type, file, dest, oncomplete) {
       if (error.message.length > 0) {
         oncomplete(error);
       } else {
-        alert(type + '\n' + filename + '\n' + file.name + '\n' + file.type);
         oncomplete(new Error('Attempt to write to an invalid storage. Abort.'));
       }
     } else {

--- a/modules/messages.js
+++ b/modules/messages.js
@@ -4,6 +4,7 @@
 var Messages = function() {};
 
 /**
+ * @access private
  * @description Messages constructor
  */
 Messages.prototype.initialize = function() {};

--- a/modules/music.js
+++ b/modules/music.js
@@ -5,11 +5,13 @@
 function Music() {}
 
 /**
+ * @access private
  * @description Music initializer.
  */
 Music.prototype.initialize = function() {};
 
 /**
+ * @access public
  * @description Wrapper that calls ffosbr.backup('music').
  *  Oncomplete callback is invoked upon completion; if an error occurred,
  *  it will be passed as the first parameter to the callback.
@@ -22,6 +24,7 @@ Music.prototype.backup = function(oncomplete) {
 };
 
 /**
+ * @access public
  * @description Wrapper for ffosbr.restore('music').
  *  Oncomplete callback is invoked upon completion.
  * @param {callback} oncomplete
@@ -33,6 +36,7 @@ Music.prototype.restore = function(oncomplete) {
 };
 
 /**
+ * @access public
  * @description Wrapper for ffosbr.clean('music').
  *  Oncomplete callback is invoked upon completion.
  * @param {callback} oncomplete

--- a/modules/music.js
+++ b/modules/music.js
@@ -16,7 +16,9 @@ Music.prototype.initialize = function() {};
  * @param {callback} oncomplete
  */
 Music.prototype.backup = function(oncomplete) {
-  ffosbr.backup('music', oncomplete);
+  ffosbr.backup('music', function() {
+    oncomplete();
+  });
 };
 
 /**
@@ -25,7 +27,9 @@ Music.prototype.backup = function(oncomplete) {
  * @param {callback} oncomplete
  */
 Music.prototype.restore = function(oncomplete) {
-  ffosbr.restore('music', oncomplete);
+  ffosbr.restore('music', function() {
+    oncomplete();
+  });
 };
 
 /**

--- a/modules/music.js
+++ b/modules/music.js
@@ -18,9 +18,7 @@ Music.prototype.initialize = function() {};
  * @param {callback} oncomplete
  */
 Music.prototype.backup = function(oncomplete) {
-  ffosbr.backup('music', function() {
-    oncomplete();
-  });
+  ffosbr.backup('music', oncomplete);
 };
 
 /**
@@ -30,9 +28,7 @@ Music.prototype.backup = function(oncomplete) {
  * @param {callback} oncomplete
  */
 Music.prototype.restore = function(oncomplete) {
-  ffosbr.restore('music', function() {
-    oncomplete();
-  });
+  ffosbr.restore('music', oncomplete);
 };
 
 /**

--- a/modules/music.js
+++ b/modules/music.js
@@ -1,0 +1,40 @@
+/**
+ * Wrapper module that allows Music to be backed up using standard backup/restore/clean
+ * methods.
+ */
+function Music() {}
+
+/**
+ * @description Music initializer.
+ */
+Music.prototype.initialize = function() {};
+
+/**
+ * @description Wrapper that calls ffosbr.backup('music').
+ *  Oncomplete callback is invoked upon completion; if an error occurred,
+ *  it will be passed as the first parameter to the callback.
+ * @param {callback} oncomplete
+ */
+Music.prototype.backup = function(oncomplete) {
+  ffosbr.backup('music', oncomplete);
+};
+
+/**
+ * @description Wrapper for ffosbr.restore('music').
+ *  Oncomplete callback is invoked upon completion.
+ * @param {callback} oncomplete
+ */
+Music.prototype.restore = function(oncomplete) {
+  ffosbr.restore('music', oncomplete);
+};
+
+/**
+ * @description Wrapper for ffosbr.clean('music').
+ *  Oncomplete callback is invoked upon completion.
+ * @param {callback} oncomplete
+ */
+Music.prototype.clean = function(oncomplete) {
+  ffosbr.clean('music', oncomplete);
+};
+
+module.exports = new Music();

--- a/modules/photos.js
+++ b/modules/photos.js
@@ -1,0 +1,40 @@
+/**
+ * Wrapper module that allows Photos to be backed up using standard backup/restore/clean
+ * methods.
+ */
+function Photos() {}
+
+/**
+ * @description Photos initializer.
+ */
+Photos.prototype.initialize = function() {};
+
+/**
+ * @description Wrapper that calls ffosbr.backup('pictures').
+ *  Oncomplete callback is invoked upon completion; if an error occurred,
+ *  it will be passed as the first parameter to the callback.
+ * @param {callback} oncomplete
+ */
+Photos.prototype.backup = function(oncomplete) {
+  ffosbr.backup('pictures', oncomplete);
+};
+
+/**
+ * @description Wrapper for ffosbr.restore('pictures').
+ *  Oncomplete callback is invoked upon completion.
+ * @param {callback} oncomplete
+ */
+Photos.prototype.restore = function(oncomplete) {
+  ffosbr.restore('pictures', oncomplete);
+};
+
+/**
+ * @description Wrapper for ffosbr.clean('pictures').
+ *  Oncomplete callback is invoked upon completion.
+ * @param {callback} oncomplete
+ */
+Photos.prototype.clean = function(oncomplete) {
+  ffosbr.clean('pictures', oncomplete);
+};
+
+module.exports = new Photos();

--- a/modules/photos.js
+++ b/modules/photos.js
@@ -10,7 +10,7 @@ function Photos() {}
 Photos.prototype.initialize = function() {};
 
 /**
- * @description Wrapper that calls ffosbr.backup('pictures').
+ * @description Wrapper that calls ffosbr.backup('photos').
  *  Oncomplete callback is invoked upon completion; if an error occurred,
  *  it will be passed as the first parameter to the callback.
  * @param {callback} oncomplete
@@ -22,23 +22,23 @@ Photos.prototype.backup = function(oncomplete) {
 };
 
 /**
- * @description Wrapper for ffosbr.restore('pictures').
+ * @description Wrapper for ffosbr.restore('photos').
  *  Oncomplete callback is invoked upon completion.
  * @param {callback} oncomplete
  */
 Photos.prototype.restore = function(oncomplete) {
-  ffosbr.restore('pictures', function() {
+  ffosbr.restore('photos', function() {
     oncomplete();
   });
 };
 
 /**
- * @description Wrapper for ffosbr.clean('pictures').
+ * @description Wrapper for ffosbr.clean('photos').
  *  Oncomplete callback is invoked upon completion.
  * @param {callback} oncomplete
  */
 Photos.prototype.clean = function(oncomplete) {
-  ffosbr.clean('pictures', oncomplete);
+  ffosbr.clean('photos', oncomplete);
 };
 
 module.exports = new Photos();

--- a/modules/photos.js
+++ b/modules/photos.js
@@ -16,7 +16,9 @@ Photos.prototype.initialize = function() {};
  * @param {callback} oncomplete
  */
 Photos.prototype.backup = function(oncomplete) {
-  ffosbr.backup('pictures', oncomplete);
+  ffosbr.backup('photos', function() {
+    oncomplete();
+  });
 };
 
 /**
@@ -25,7 +27,9 @@ Photos.prototype.backup = function(oncomplete) {
  * @param {callback} oncomplete
  */
 Photos.prototype.restore = function(oncomplete) {
-  ffosbr.restore('pictures', oncomplete);
+  ffosbr.restore('pictures', function() {
+    oncomplete();
+  });
 };
 
 /**

--- a/modules/photos.js
+++ b/modules/photos.js
@@ -18,9 +18,7 @@ Photos.prototype.initialize = function() {};
  * @param {callback} oncomplete
  */
 Photos.prototype.backup = function(oncomplete) {
-  ffosbr.backup('photos', function() {
-    oncomplete();
-  });
+  ffosbr.backup('photos', oncomplete);
 };
 
 /**
@@ -30,9 +28,7 @@ Photos.prototype.backup = function(oncomplete) {
  * @param {callback} oncomplete
  */
 Photos.prototype.restore = function(oncomplete) {
-  ffosbr.restore('photos', function() {
-    oncomplete();
-  });
+  ffosbr.restore('photos', oncomplete);
 };
 
 /**

--- a/modules/photos.js
+++ b/modules/photos.js
@@ -5,11 +5,13 @@
 function Photos() {}
 
 /**
+ * @access private
  * @description Photos initializer.
  */
 Photos.prototype.initialize = function() {};
 
 /**
+ * @access public
  * @description Wrapper that calls ffosbr.backup('photos').
  *  Oncomplete callback is invoked upon completion; if an error occurred,
  *  it will be passed as the first parameter to the callback.
@@ -22,6 +24,7 @@ Photos.prototype.backup = function(oncomplete) {
 };
 
 /**
+ * @access public
  * @description Wrapper for ffosbr.restore('photos').
  *  Oncomplete callback is invoked upon completion.
  * @param {callback} oncomplete
@@ -33,6 +36,7 @@ Photos.prototype.restore = function(oncomplete) {
 };
 
 /**
+ * @access public
  * @description Wrapper for ffosbr.clean('photos').
  *  Oncomplete callback is invoked upon completion.
  * @param {callback} oncomplete

--- a/modules/restore.js
+++ b/modules/restore.js
@@ -22,12 +22,14 @@ var restore = function(type, oncomplete) {
     var filename = fn.substr(fn.lastIndexOf('/') + 1, fn.length);
 
     ffosbr.media.put(type === 'photos' ? 'pictures' : type, file, filename, function(error) {
-      if (error) {
+      if (ffosbr.utils.isFunction(oncomplete)) {
         oncomplete(error);
       }
     });
-  }, function() {
-    oncomplete();
+  }, function(error) {
+    if(ffosbr.utils.isFunction(oncomplete)) {
+      oncomplete(error);
+    }
   });
 };
 

--- a/modules/restore.js
+++ b/modules/restore.js
@@ -11,8 +11,6 @@
  */
 var restore = function(type, oncomplete) {
 
-  var externalSD = null;
-  var restoreFiles = null;
   var paths = ffosbr.settings.getBackupDirectoryPaths();
 
   ffosbr.media.get('sdcard1', '/' + paths[type], function(file) {

--- a/modules/restore.js
+++ b/modules/restore.js
@@ -13,23 +13,30 @@ var restore = function(type, oncomplete) {
 
   var paths = ffosbr.settings.getBackupDirectoryPaths();
 
-  ffosbr.media.get('sdcard1', '/' + paths[type], function(file) {
+  ffosbr.media.get('sdcard1', paths[type], function(file) {
     if (!file) {
       return;
     }
 
     var fn = file.name;
+    if (fn.endsWith('~')) {
+      fn = fn.substr(0, fn.length - 1);
+    }
     var filename = fn.substr(fn.lastIndexOf('/') + 1, fn.length);
 
-    ffosbr.media.put(type === 'photos' ? 'pictures' : type, file, filename, function(error) {
-      if (ffosbr.utils.isFunction(oncomplete)) {
-        oncomplete(error);
-      }
-    });
-  }, function(error) {
-    if (ffosbr.utils.isFunction(oncomplete)) {
-      oncomplete(error);
-    }
+    var reader = new FileReader();
+
+    reader.onloadend = function() {
+      var fc = this.result;
+      var newFile = new File([fc], filename, {
+        type: 'image/jpeg'
+      });
+      newFile.type = 'image/jpeg';
+
+      ffosbr.media.put(type === 'photos' ? 'pictures' : type, newFile, filename, oncomplete);
+    };
+
+    reader.readAsArrayBuffer(file);
   });
 };
 

--- a/modules/restore.js
+++ b/modules/restore.js
@@ -23,15 +23,31 @@ var restore = function(type, oncomplete) {
       fn = fn.substr(0, fn.length - 1);
     }
     var filename = fn.substr(fn.lastIndexOf('/') + 1, fn.length);
+    var extension = fn.substr(fn.lastIndexOf('.') + 1, fn.length);
+
+    var mimeType;
+    switch (extension) {
+      case 'jpg':
+        mimeType = 'image/jpeg';
+        break;
+      case 'png':
+        mimeType = 'image/png';
+        break;
+      case '3gp':
+        mimeType = 'video/3gpp';
+        break;
+      default:
+        // Text I guess?
+        mimeType = 'application/json';
+    }
 
     var reader = new FileReader();
 
     reader.onloadend = function() {
       var fc = this.result;
       var newFile = new File([fc], filename, {
-        type: 'image/jpeg'
+        type: mimeType
       });
-      newFile.type = 'image/jpeg';
 
       ffosbr.media.put(type === 'photos' ? 'pictures' : type, newFile, filename, oncomplete);
     };

--- a/modules/restore.js
+++ b/modules/restore.js
@@ -27,7 +27,7 @@ var restore = function(type, oncomplete) {
       }
     });
   }, function(error) {
-    if(ffosbr.utils.isFunction(oncomplete)) {
+    if (ffosbr.utils.isFunction(oncomplete)) {
       oncomplete(error);
     }
   });

--- a/modules/settings.js
+++ b/modules/settings.js
@@ -1,3 +1,7 @@
+/**
+ * Manages library settings and exposes ways to change them.
+ */
+
 function Settings() {
 
   this.options = {
@@ -24,6 +28,7 @@ function Settings() {
 }
 
 /**
+ * @access private
  * @description Settings constructor
  */
 Settings.prototype.initialize = function() {
@@ -37,6 +42,10 @@ Settings.prototype.initialize = function() {
   }
 };
 
+/**
+ * @access private
+ * @description Load previous settings from local storage if they exist
+ */
 Settings.prototype.load = function() {
   // Load options if present
   var retrievedOptions = localStorage.getItem('ffosbrOptions');
@@ -59,6 +68,10 @@ Settings.prototype.load = function() {
   }
 };
 
+/**
+ * @access private
+ * @description Load previous settings from local storage if they exist
+ */
 Settings.prototype.getBackupDirectoryPaths = function() {
   var paths = {};
   for (var field in this.backupPaths) {
@@ -67,6 +80,13 @@ Settings.prototype.getBackupDirectoryPaths = function() {
   return paths;
 };
 
+/**
+ * @access private
+ * @description Validate passed in setting
+ * @para {object} potentialOptions
+ * @para {object}  value
+ * @return True if passed in settings are valid otherwise false
+ */
 Settings.prototype.validate = function(potentialOptions, value) {
 
   var valid = true;
@@ -114,6 +134,13 @@ Settings.prototype.validate = function(potentialOptions, value) {
   return valid;
 };
 
+/**
+ * @access public
+ * @description Set settings
+ * @para {setting object} newOptions
+ * @para {object} value (optional)
+ * @throws if new value is invalid
+ */
 Settings.prototype.set = function(newOptions, value) {
 
   var opts = null;
@@ -148,6 +175,12 @@ Settings.prototype.set = function(newOptions, value) {
   localStorage.setItem('ffosbrOptions', JSON.stringify(this.options));
 };
 
+/**
+ * @access public
+ * @description Get's current settings or a particular field if passsed in
+ * @para {object} field (optional)
+ * @return current options
+ */
 Settings.prototype.get = function(field) {
 
   if (typeof field === 'undefined') {

--- a/modules/settings.js
+++ b/modules/settings.js
@@ -1,7 +1,6 @@
 /**
  * Manages library settings and exposes ways to change them.
  */
-
 function Settings() {
 
   this.options = {

--- a/modules/storage.js
+++ b/modules/storage.js
@@ -1,4 +1,5 @@
 /**
+ * @access private
  * @description Basic "storage" class to help simplify code in the
  *  Media module, and help offload some functionality in detecting
  *  write-collisions. The main purpose of this class is to indicate
@@ -8,6 +9,7 @@
  *   Note: See Media > storageTypes for a list of valid types.
  * @param {DeviceStorage} store: The DeviceStorage used by this
  *   storage instance.
+ * @throws on invalid media type of device storage
  */
 function Storage(type, store) {
 
@@ -29,6 +31,7 @@ function Storage(type, store) {
 }
 
 /**
+ * @access private
  * @description Reports whether or not a file exists in a
  *   given storage.
  * @param {string} fname: Name of file to check.
@@ -55,9 +58,11 @@ Storage.prototype.fileExists = function(fname, oncomplete) {
 };
 
 /**
+ * @access private
  * @description Enumerates all files on storage and adds them to
  *   the "files" object. This is used for tracking what files
  *   exist in the storage at all times.
+ * @throws if fails access storage
  */
 Storage.prototype.populate = function() {
 
@@ -89,6 +94,7 @@ Storage.prototype.populate = function() {
 };
 
 /**
+ * @access private
  * @description Sanitizes file names such that they are valid
  *   object keys.
  * @fname File name to sanitize.

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -4,12 +4,13 @@
 var Utilities = function() {};
 
 /**
+ * @access private
  * @description Utilities constructor
  */
 Utilities.prototype.initialize = function() {};
 
 /**
- * @access public
+ * @access private
  * @description Determines whether an object is a function.
  * @param {any} functionToCheck
  * @returns {boolean}

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -4,13 +4,13 @@
 var Utilities = function() {};
 
 /**
- * @access private
+ * @access public
  * @description Utilities constructor
  */
 Utilities.prototype.initialize = function() {};
 
 /**
- * @access private
+ * @access public
  * @description Determines whether an object is a function.
  * @param {any} functionToCheck
  * @returns {boolean}

--- a/modules/videos.js
+++ b/modules/videos.js
@@ -5,11 +5,13 @@
 function Videos() {}
 
 /**
+ * @access private
  * @description Videos initializer.
  */
 Videos.prototype.initialize = function() {};
 
 /**
+ * @access public
  * @description Wrapper that calls ffosbr.backup('videos').
  *  Oncomplete callback is invoked upon completion; if an error occurred,
  *  it will be passed as the first parameter to the callback.
@@ -22,6 +24,7 @@ Videos.prototype.backup = function(oncomplete) {
 };
 
 /**
+ * @access public
  * @description Wrapper for ffosbr.restore('videos').
  *  Oncomplete callback is invoked upon completion.
  * @param {callback} oncomplete
@@ -33,6 +36,7 @@ Videos.prototype.restore = function(oncomplete) {
 };
 
 /**
+ * @access public
  * @description Wrapper for ffosbr.clean('videos').
  *  Oncomplete callback is invoked upon completion.
  * @param {callback} oncomplete

--- a/modules/videos.js
+++ b/modules/videos.js
@@ -1,0 +1,40 @@
+/**
+ * Wrapper module that allows Videos to be backed up using standard backup/restore/clean
+ * methods.
+ */
+function Videos() {}
+
+/**
+ * @description Videos initializer.
+ */
+Videos.prototype.initialize = function() {};
+
+/**
+ * @description Wrapper that calls ffosbr.backup('videos').
+ *  Oncomplete callback is invoked upon completion; if an error occurred,
+ *  it will be passed as the first parameter to the callback.
+ * @param {callback} oncomplete
+ */
+Videos.prototype.backup = function(oncomplete) {
+  ffosbr.backup('videos', oncomplete);
+};
+
+/**
+ * @description Wrapper for ffosbr.restore('videos').
+ *  Oncomplete callback is invoked upon completion.
+ * @param {callback} oncomplete
+ */
+Videos.prototype.restore = function(oncomplete) {
+  ffosbr.restore('videos', oncomplete);
+};
+
+/**
+ * @description Wrapper for ffosbr.clean('videos').
+ *  Oncomplete callback is invoked upon completion.
+ * @param {callback} oncomplete
+ */
+Videos.prototype.clean = function(oncomplete) {
+  ffosbr.clean('videos', oncomplete);
+};
+
+module.exports = new Videos();

--- a/modules/videos.js
+++ b/modules/videos.js
@@ -16,7 +16,9 @@ Videos.prototype.initialize = function() {};
  * @param {callback} oncomplete
  */
 Videos.prototype.backup = function(oncomplete) {
-  ffosbr.backup('videos', oncomplete);
+  ffosbr.backup('videos', function() {
+    oncomplete();
+  });
 };
 
 /**
@@ -25,7 +27,9 @@ Videos.prototype.backup = function(oncomplete) {
  * @param {callback} oncomplete
  */
 Videos.prototype.restore = function(oncomplete) {
-  ffosbr.restore('videos', oncomplete);
+  ffosbr.restore('videos', function() {
+    oncomplete();
+  });
 };
 
 /**

--- a/modules/videos.js
+++ b/modules/videos.js
@@ -18,9 +18,7 @@ Videos.prototype.initialize = function() {};
  * @param {callback} oncomplete
  */
 Videos.prototype.backup = function(oncomplete) {
-  ffosbr.backup('videos', function() {
-    oncomplete();
-  });
+  ffosbr.backup('videos', oncomplete);
 };
 
 /**
@@ -30,9 +28,7 @@ Videos.prototype.backup = function(oncomplete) {
  * @param {callback} oncomplete
  */
 Videos.prototype.restore = function(oncomplete) {
-  ffosbr.restore('videos', function() {
-    oncomplete();
-  });
+  ffosbr.restore('videos', oncomplete);
 };
 
 /**

--- a/testrunner/manifest.webapp
+++ b/testrunner/manifest.webapp
@@ -19,6 +19,7 @@
     },
     "device-storage:sdcard": { "access": "readwrite" },
     "device-storage:pictures":{ "access": "readwrite" },
+    "device-storage:videos":{ "access": "readwrite" },
     "contacts": { "access": "readwrite" },
     "mobileconnection":{},
     "sms":{}

--- a/testrunner/tests/media.spec.js
+++ b/testrunner/tests/media.spec.js
@@ -122,7 +122,7 @@ QUnit.test('Get media from storage', function(assert) {
     );
   });
 
-  // NOTE: Media.get() as no return value, so if it worked and doesn't
+  // NOTE: Media.get() has no return value, so if it worked and doesn't
   // throw an error, the return value should be "undefined".
   ffosbr.media.get('sdcard1', function(file, err) {
     assert.strictEqual(
@@ -190,10 +190,6 @@ QUnit.test('Put media to storage', function(assert) {
       '...throws error when there is not an external sdcard'
     );
   });
-
-  //TODO
-  //destination is ignored unless type is sdcard1 make sure it's ignored
-  //make sure dest affects where files are written ?? human test
 
 
 });


### PR DESCRIPTION
• Backup, clean, and restore have been modernized and now use `ffosbr.media.get()`.
• Modifies `ffosbr.media.get()` so that it now takes two callbacks, `forEach` and `oncomplete`
• Uses `String.prototype.startsWith()` to work around a bug in FXOS that causes `DeviceStorage.prototype.enumerate()` to ignore its `path` argument

ISSUES
• Fixes #30
• Closes #29 
• Fixes #24 
• Fixes #25 
• Fixes #26
